### PR TITLE
Update import path for count_params in SimCLR.py

### DIFF
--- a/SimCLR.py
+++ b/SimCLR.py
@@ -8,7 +8,8 @@ from tensorflow.keras.callbacks import (
     EarlyStopping,
     ReduceLROnPlateau,
 )
-from keras.utils.layer_utils import count_params
+# from keras.utils.layer_utils import count_params
+from tensorflow.keras.utils import count_params
 
 from datetime import datetime
 


### PR DESCRIPTION
- Changed `from keras.utils.layer_utils import count_params` to `from tensorflow.keras.utils import count_params` to fix ModuleNotFoundError due to outdated Keras API.
- No functional changes to SimCLR logic; only import fix.